### PR TITLE
Correction: removed NaNs from the final db

### DIFF
--- a/ETL Pipeline Preparation.ipynb
+++ b/ETL Pipeline Preparation.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -111,7 +111,7 @@
        "4  facade ouest d Haiti et le reste du pays aujou...  direct  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -191,7 +191,7 @@
        "4  12  related-1;request-0;offer-0;aid_related-0;medi..."
       ]
      },
-     "execution_count": 17,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -312,7 +312,7 @@
        "4  related-1;request-0;offer-0;aid_related-0;medi...  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -547,20 +547,20 @@
        "[5 rows x 36 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# create a dataframe of the 36 individual category columns\n",
-    "categories = categories['categories'].str.split(';', expand = True)\n",
+    "categories = df['categories'].str.split(';', expand = True)\n",
     "categories.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -832,7 +832,7 @@
        "[5 rows x 36 columns]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -854,7 +854,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1059,7 +1059,7 @@
        "[5 rows x 36 columns]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1086,7 +1086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -1172,7 +1172,7 @@
        "4  facade ouest d Haiti et le reste du pays aujou...  direct  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1186,7 +1186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1240,23 +1240,23 @@
        "      <td>Weather update - a cold front from Cuba that c...</td>\n",
        "      <td>Un front froid se retrouve sur Cuba ce matin. ...</td>\n",
        "      <td>direct</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1264,23 +1264,23 @@
        "      <td>Is the Hurricane over or is it not over</td>\n",
        "      <td>Cyclone nan fini osinon li pa fini</td>\n",
        "      <td>direct</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1288,23 +1288,23 @@
        "      <td>Looking for someone but no name</td>\n",
        "      <td>Patnm, di Maryani relem pou li banm nouvel li ...</td>\n",
        "      <td>direct</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1312,23 +1312,23 @@
        "      <td>UN reports Leogane 80-90 destroyed. Only Hospi...</td>\n",
        "      <td>UN reports Leogane 80-90 destroyed. Only Hospi...</td>\n",
        "      <td>direct</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1336,23 +1336,23 @@
        "      <td>says: west side of Haiti, rest of the country ...</td>\n",
        "      <td>facade ouest d Haiti et le reste du pays aujou...</td>\n",
        "      <td>direct</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1368,37 +1368,37 @@
        "4  12  says: west side of Haiti, rest of the country ...   \n",
        "\n",
        "                                            original   genre  related  \\\n",
-       "0  Un front froid se retrouve sur Cuba ce matin. ...  direct      1.0   \n",
-       "1                 Cyclone nan fini osinon li pa fini  direct      1.0   \n",
-       "2  Patnm, di Maryani relem pou li banm nouvel li ...  direct      1.0   \n",
-       "3  UN reports Leogane 80-90 destroyed. Only Hospi...  direct      1.0   \n",
-       "4  facade ouest d Haiti et le reste du pays aujou...  direct      1.0   \n",
+       "0  Un front froid se retrouve sur Cuba ce matin. ...  direct        1   \n",
+       "1                 Cyclone nan fini osinon li pa fini  direct        1   \n",
+       "2  Patnm, di Maryani relem pou li banm nouvel li ...  direct        1   \n",
+       "3  UN reports Leogane 80-90 destroyed. Only Hospi...  direct        1   \n",
+       "4  facade ouest d Haiti et le reste du pays aujou...  direct        1   \n",
        "\n",
        "   request  offer  aid_related  medical_help  medical_products  ...  \\\n",
-       "0      0.0    0.0          0.0           0.0               0.0  ...   \n",
-       "1      0.0    0.0          1.0           0.0               0.0  ...   \n",
-       "2      0.0    0.0          0.0           0.0               0.0  ...   \n",
-       "3      1.0    0.0          1.0           0.0               1.0  ...   \n",
-       "4      0.0    0.0          0.0           0.0               0.0  ...   \n",
+       "0        0      0            0             0                 0  ...   \n",
+       "1        0      0            1             0                 0  ...   \n",
+       "2        0      0            0             0                 0  ...   \n",
+       "3        1      0            1             0                 1  ...   \n",
+       "4        0      0            0             0                 0  ...   \n",
        "\n",
        "   aid_centers  other_infrastructure  weather_related  floods  storm  fire  \\\n",
-       "0          0.0                   0.0              0.0     0.0    0.0   0.0   \n",
-       "1          0.0                   0.0              1.0     0.0    1.0   0.0   \n",
-       "2          0.0                   0.0              0.0     0.0    0.0   0.0   \n",
-       "3          0.0                   0.0              0.0     0.0    0.0   0.0   \n",
-       "4          0.0                   0.0              0.0     0.0    0.0   0.0   \n",
+       "0            0                     0                0       0      0     0   \n",
+       "1            0                     0                1       0      1     0   \n",
+       "2            0                     0                0       0      0     0   \n",
+       "3            0                     0                0       0      0     0   \n",
+       "4            0                     0                0       0      0     0   \n",
        "\n",
        "   earthquake  cold  other_weather  direct_report  \n",
-       "0         0.0   0.0            0.0            0.0  \n",
-       "1         0.0   0.0            0.0            0.0  \n",
-       "2         0.0   0.0            0.0            0.0  \n",
-       "3         0.0   0.0            0.0            0.0  \n",
-       "4         0.0   0.0            0.0            0.0  \n",
+       "0           0     0              0              0  \n",
+       "1           0     0              0              0  \n",
+       "2           0     0              0              0  \n",
+       "3           0     0              0              0  \n",
+       "4           0     0              0              0  \n",
        "\n",
        "[5 rows x 40 columns]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1421,16 +1421,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "41"
+       "170"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1442,7 +1442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1452,7 +1452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1461,44 +1461,44 @@
      "text": [
       "id                            0\n",
       "message                       0\n",
-      "original                  16122\n",
+      "original                  16046\n",
       "genre                         0\n",
-      "related                     138\n",
-      "request                     138\n",
-      "offer                       138\n",
-      "aid_related                 138\n",
-      "medical_help                138\n",
-      "medical_products            138\n",
-      "search_and_rescue           138\n",
-      "security                    138\n",
-      "military                    138\n",
-      "child_alone                 138\n",
-      "water                       138\n",
-      "food                        138\n",
-      "shelter                     138\n",
-      "clothing                    138\n",
-      "money                       138\n",
-      "missing_people              138\n",
-      "refugees                    138\n",
-      "death                       138\n",
-      "other_aid                   138\n",
-      "infrastructure_related      138\n",
-      "transport                   138\n",
-      "buildings                   138\n",
-      "electricity                 138\n",
-      "tools                       138\n",
-      "hospitals                   138\n",
-      "shops                       138\n",
-      "aid_centers                 138\n",
-      "other_infrastructure        138\n",
-      "weather_related             138\n",
-      "floods                      138\n",
-      "storm                       138\n",
-      "fire                        138\n",
-      "earthquake                  138\n",
-      "cold                        138\n",
-      "other_weather               138\n",
-      "direct_report               138\n",
+      "related                       0\n",
+      "request                       0\n",
+      "offer                         0\n",
+      "aid_related                   0\n",
+      "medical_help                  0\n",
+      "medical_products              0\n",
+      "search_and_rescue             0\n",
+      "security                      0\n",
+      "military                      0\n",
+      "child_alone                   0\n",
+      "water                         0\n",
+      "food                          0\n",
+      "shelter                       0\n",
+      "clothing                      0\n",
+      "money                         0\n",
+      "missing_people                0\n",
+      "refugees                      0\n",
+      "death                         0\n",
+      "other_aid                     0\n",
+      "infrastructure_related        0\n",
+      "transport                     0\n",
+      "buildings                     0\n",
+      "electricity                   0\n",
+      "tools                         0\n",
+      "hospitals                     0\n",
+      "shops                         0\n",
+      "aid_centers                   0\n",
+      "other_infrastructure          0\n",
+      "weather_related               0\n",
+      "floods                        0\n",
+      "storm                         0\n",
+      "fire                          0\n",
+      "earthquake                    0\n",
+      "cold                          0\n",
+      "other_weather                 0\n",
+      "direct_report                 0\n",
       "dtype: int64\n"
      ]
     }
@@ -1520,9 +1520,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "26216"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "engine = create_engine('sqlite:///InsertDatabaseName.db')\n",
     "df.to_sql('Clean_Disaster_Data', engine, index=False)"
@@ -1658,7 +1669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The issue begins from the code cell 5 of ETL pipeline preparation notebook where you are splitting the categories column.
![](https://udacity-user-uploads.s3.us-west-2.amazonaws.com/uploads/user-uploads/104c3147-263b-4738-bbef-0974579a40d6-mobile.jpeg)

As you can see following dataframes have different number of observations.
![](https://udacity-user-uploads.s3.us-west-2.amazonaws.com/uploads/user-uploads/1ca10d33-9a8f-44ed-b2ef-6884656178af-mobile.jpeg)

So when you try to concat these two dataframes, it will create observations filled with NaN wherever there is a mismatch in the rows of the two dataframes.
![](https://udacity-user-uploads.s3.us-west-2.amazonaws.com/uploads/user-uploads/31758e36-0d16-482e-9033-231463eb9e11-desktop.jpeg)


